### PR TITLE
Bump hugo version

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,5 +2,8 @@
   publish = "public/"
   command = "hugo -d public -b https://www.gemcityswing.com"
 
+[build.environment]
+  HUGO_VERSION = "0.135.0"
+
 [context.production]
   environment = { HUGO_ENV = "production" }


### PR DESCRIPTION
Website is currently being built on a 2019 version of hugo, and doesn't build the updated theme.  Let's bump the hugo version