### PR TITLE
Center header images vertically when cropped

### DIFF
--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -1,0 +1,26 @@
+{{/* DO NOT MODIFY THIS FILE DIRECTLY!  Instead, use the provided scripts to generate this file from the theme */}}
+{{ $featured_image := partial "func/GetFeaturedImage.html" . }}
+{{ if $featured_image }}
+  {{/* Trimming the slash and adding absURL make sure the image works no matter where our site lives */}}
+  <header class="cover bg-center" style="background-image: url('{{ $featured_image }}');">
+    <div class="bg-black-60">
+      {{ partial "site-navigation.html" . }}
+      <div class="tc-l pv6 ph3 ph4-ns">
+        {{ if not .Params.omit_header_text }}
+          <div class="f2 f1-l fw2 white-90 mb0 lh-title">{{ .Title | default .Site.Title }}</div>
+          {{ with .Params.description  }}
+            <div class="fw1 f5 f3-l white-80 measure-wide-l center lh-copy mt3 mb4">
+              {{ . }}
+            </div>
+          {{ end }}
+        {{ end }}
+      </div>
+    </div>
+  </header>
+{{ else }}
+  <header>
+    <div class="{{ .Site.Params.background_color_class | default "bg-black" }}">
+      {{ partial "site-navigation.html" . }}
+    </div>
+  </header>
+{{ end }}

--- a/layouts/partials/site-header.html
+++ b/layouts/partials/site-header.html
@@ -1,0 +1,36 @@
+{{/* DO NOT MODIFY THIS FILE DIRECTLY!  Instead, use the provided scripts to generate this file from the theme */}}
+{{ $featured_image := partial "func/GetFeaturedImage.html" . }}
+{{ if $featured_image }}
+  {{/* Trimming the slash and adding absURL make sure the image works no matter where our site lives */}}
+  <header class="cover bg-center" style="background-image: url('{{ $featured_image }}');">
+    <div class="{{ .Site.Params.cover_dimming_class | default "bg-black-60" }}">
+      {{ partial "site-navigation.html" .}}
+      <div class="tc-l pv4 pv6-l ph3 ph4-ns">
+        <h1 class="f2 f-subheadline-l fw2 white-90 mb0 lh-title">
+          {{ .Title | default .Site.Title }}
+        </h1>
+        {{ with .Params.description }}
+          <h2 class="fw1 f5 f3-l white-80 measure-wide-l center mt3">
+            {{ . }}
+          </h2>
+        {{ end }}
+      </div>
+    </div>
+  </header>
+{{ else }}
+  <header>
+    <div class="pb3-m pb6-l {{ .Site.Params.background_color_class | default "bg-black" }}">
+      {{ partial "site-navigation.html" . }}
+      <div class="tc-l pv3 ph3 ph4-ns">
+        <h1 class="f2 f-subheadline-l fw2 light-silver mb0 lh-title">
+          {{ .Title | default .Site.Title }}
+        </h1>
+        {{ with .Params.description }}
+          <h2 class="fw1 f5 f3-l white-80 measure-wide-l center lh-copy mt3 mb4">
+            {{ . }}
+          </h2>
+        {{ end }}
+      </div>
+    </div>
+  </header>
+{{ end }}

--- a/patches/partials/page-header.html.patch
+++ b/patches/partials/page-header.html.patch
@@ -1,0 +1,12 @@
+--- themes/gohugo-theme-ananke/layouts/partials/page-header.html	2024-12-09 21:38:44.767311747 -0500
++++ layouts/partials/page-header.html	2024-12-12 09:21:35.642487591 -0500
+@@ -1,7 +1,8 @@
++{{/* DO NOT MODIFY THIS FILE DIRECTLY!  Instead, use the provided scripts to generate this file from the theme */}}
+ {{ $featured_image := partial "func/GetFeaturedImage.html" . }}
+ {{ if $featured_image }}
+   {{/* Trimming the slash and adding absURL make sure the image works no matter where our site lives */}}
+-  <header class="cover bg-top" style="background-image: url('{{ $featured_image }}');">
++  <header class="cover bg-center" style="background-image: url('{{ $featured_image }}');">
+     <div class="bg-black-60">
+       {{ partial "site-navigation.html" . }}
+       <div class="tc-l pv6 ph3 ph4-ns">

--- a/patches/partials/site-header.html.patch
+++ b/patches/partials/site-header.html.patch
@@ -1,0 +1,12 @@
+--- themes/gohugo-theme-ananke/layouts/partials/site-header.html	2024-12-12 09:20:41.191814138 -0500
++++ layouts/partials/site-header.html	2024-12-12 09:20:52.215541618 -0500
+@@ -1,7 +1,8 @@
++{{/* DO NOT MODIFY THIS FILE DIRECTLY!  Instead, use the provided scripts to generate this file from the theme */}}
+ {{ $featured_image := partial "func/GetFeaturedImage.html" . }}
+ {{ if $featured_image }}
+   {{/* Trimming the slash and adding absURL make sure the image works no matter where our site lives */}}
+-  <header class="cover bg-top" style="background-image: url('{{ $featured_image }}');">
++  <header class="cover bg-center" style="background-image: url('{{ $featured_image }}');">
+     <div class="{{ .Site.Params.cover_dimming_class | default "bg-black-60" }}">
+       {{ partial "site-navigation.html" .}}
+       <div class="tc-l pv4 pv6-l ph3 ph4-ns">

--- a/scripts/gen-overrides.sh
+++ b/scripts/gen-overrides.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+echo "Generating template overrides based on patches..."
+
+OVERRIDE_FILES=("partials/site-header.html" "partials/page-header.html")
+
+for file in "${OVERRIDE_FILES[@]}"; do
+  cp themes/gohugo-theme-ananke/layouts/$file layouts/$file
+  patch -u layouts/$file < patches/$file.patch
+done

--- a/scripts/gen-patch-files.sh
+++ b/scripts/gen-patch-files.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+echo "Generating patch files based on overridden template files..."
+mkdir -p patches/partials/
+
+OVERRIDE_FILES=("partials/site-header.html" "partials/page-header.html")
+
+for file in "${OVERRIDE_FILES[@]}"; do
+  diff -u themes/gohugo-theme-ananke/layouts/$file layouts/$file > patches/$file.patch
+done


### PR DESCRIPTION
On some window widths, the site images become cropped.  This centers the images in this situation.